### PR TITLE
chore: bootstrap Claude and Codex harness docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS.md
+
+This file provides guidance to Codex and other coding agents working in this repository.
+
+For Claude Code-specific entrypoint instructions, read:
+- CLAUDE.md
+
+For durable shared project instructions, read:
+- docs/claude/README.md
+- docs/claude/project-overview.md
+- docs/claude/repository-map.md
+- docs/claude/development-workflow.md
+- docs/claude/testing-and-validation.md
+- docs/claude/security-and-secrets.md
+- docs/claude/portfolio-showcase-rules.md
+- docs/claude/release-and-git-hygiene.md
+
+Core rules for agents:
+- Treat docs/claude/ as the shared instruction source of truth.
+- Keep CLAUDE.md as the Claude Code router and AGENTS.md as the Codex/general-agent router.
+- Do not duplicate long instruction bodies across AGENTS.md and CLAUDE.md.
+- Do not expose secrets, credentials, private customer details, internal URLs, proprietary assets, or non-public business information.
+- Do not make this private repository public.
+- Public portfolio or showcase work must happen in a separate sanitized repository.
+- Before editing, check git status, current branch, and HEAD.
+- Keep edits scoped to the requested task.
+- Review git diff before staging.
+- Commit only intentional files.
+- Report final branch, commit hash, validation, and git status.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,17 @@
+# Claude Instructions
+
+This file is a concise router for Claude Code, Codex, and similar coding-agent sessions in this private repository.
+
+Start with [docs/claude/README.md](docs/claude/README.md), then use the topic file that matches the task:
+
+- [Project overview](docs/claude/project-overview.md): repository purpose, supported stack, and privacy posture.
+- [Repository map](docs/claude/repository-map.md): where important files live and what they appear to do.
+- [Development workflow](docs/claude/development-workflow.md): how to inspect and change this repo safely.
+- [Testing and validation](docs/claude/testing-and-validation.md): lightweight checks appropriate to the current file set.
+- [Security and secrets](docs/claude/security-and-secrets.md): secrets, private data, and restricted information handling.
+- [Portfolio showcase rules](docs/claude/portfolio-showcase-rules.md): rules for future public showcase extraction.
+- [Release and git hygiene](docs/claude/release-and-git-hygiene.md): branch, diff, and commit discipline.
+
+Reusable execution lessons live in `docs/solutions/`, organized by category with YAML frontmatter for search.
+
+Keep this repository private. Do not expose private customer details, internal credentials, proprietary client information, restricted government-related materials, or non-public public-sector details. Future public portfolio work must happen in a separate sanitized showcase repository, not by making this repository public.

--- a/docs/claude/README.md
+++ b/docs/claude/README.md
@@ -1,0 +1,27 @@
+# Claude Instruction Index
+
+## When to use this
+
+Use this document at the start of any Claude Code or Codex session in this repository. It explains which focused instruction file to open next.
+
+## How to use these instructions
+
+This repository uses a modular instruction structure. Read only the files relevant to the task, but always honor the privacy and git hygiene rules.
+
+- Use [project-overview.md](project-overview.md) to understand the apparent purpose, stack, and constraints inferred from repository files.
+- Use [repository-map.md](repository-map.md) when locating code, scripts, Dockerfiles, test fixtures, ignored artifacts, or documentation.
+- Use [development-workflow.md](development-workflow.md) before changing project files.
+- Use [testing-and-validation.md](testing-and-validation.md) before deciding what checks are appropriate.
+- Use [security-and-secrets.md](security-and-secrets.md) for any task involving configuration, API keys, customer data, JSON fixtures, model artifacts, vector databases, or logs.
+- Use [portfolio-showcase-rules.md](portfolio-showcase-rules.md) for any resume, portfolio, public-release, or showcase extraction work.
+- Use [release-and-git-hygiene.md](release-and-git-hygiene.md) before staging, committing, pushing, or preparing a PR.
+
+## Repository-wide rules
+
+Keep the original repository private or restricted. Do not make this repository public as a portfolio shortcut.
+
+Do not expose private customer details, internal credentials, proprietary client information, restricted government-related materials, or non-public public-sector details.
+
+Do not commit local-only task files, local secrets, model checkpoints, vector databases, datasets, logs, or generated runtime output unless the task explicitly requires it and the diff has been reviewed for sensitive content.
+
+Prefer small, grounded edits. Infer project facts from files in this repository, not from assumptions.

--- a/docs/claude/development-workflow.md
+++ b/docs/claude/development-workflow.md
@@ -1,0 +1,34 @@
+# Development Workflow
+
+## When to use this
+
+Use this before changing files in the repository.
+
+## Default workflow
+
+1. Check `git status` before editing.
+2. Read the smallest set of files needed to understand the requested change.
+3. Keep edits scoped to the task and the relevant file family.
+4. Do not rewrite unrelated code or documentation.
+5. Review the diff before reporting completion.
+6. Verify that sensitive files, ignored artifacts, and local-only task files were not staged accidentally.
+
+## Change boundaries
+
+For documentation-only tasks, do not change product source code, Dockerfiles, dependency files, lockfiles, CI, release cleanup files, or runtime configuration unless the task explicitly requires it.
+
+For product-code tasks, preserve the existing simple script-oriented structure unless there is a clear, file-supported reason to introduce new architecture.
+
+## Project-specific cautions
+
+This project uses environment-backed settings and local runtime artifacts. Do not hard-code API keys, local absolute paths, customer data, or deployment-specific secrets.
+
+The code includes Korean prompts and comments. Preserve Korean text where it carries behavior, user-facing instructions, or domain meaning. Do not translate behavior-critical text casually.
+
+Some scripts target Docker paths such as `/app/test`. When changing runtime code, account for the Docker execution model shown in `README.md` and Dockerfiles.
+
+## Dependency management
+
+The repository currently shows `requirements.txt` as the Python dependency source. Do not introduce another package manager or dependency file unless the task explicitly asks for it.
+
+Dependency changes can alter model, GPU, and Docker behavior. Treat them as higher-risk than ordinary documentation edits.

--- a/docs/claude/portfolio-showcase-rules.md
+++ b/docs/claude/portfolio-showcase-rules.md
@@ -1,0 +1,28 @@
+# Portfolio Showcase Rules
+
+## When to use this
+
+Use this for any task involving resumes, portfolio posts, public repositories, demos, screenshots, public READMEs, writeups, sanitized examples, or showcase extraction.
+
+## Core rule
+
+Do not make this original repository public. Future portfolio work must be created in a separate sanitized repository, expected to be named `franchise-modeling-chatbot-showcase` unless the user specifies otherwise.
+
+## What must be removed or rewritten before public release
+
+Before anything is copied into a public showcase, review and sanitize:
+
+- Customer, client, company, brand, contract, franchise, QA, and public-sector details.
+- API keys, W&B identifiers, local paths, logs, model artifacts, datasets, vector DBs, and generated outputs.
+- Internal comments, prompts, examples, screenshots, commit history, or filenames that reveal restricted context.
+- Any non-public government-related or public-sector information.
+
+## Showcase extraction approach
+
+Build the showcase as a separate artifact with synthetic or approved sample data. Prefer documenting architecture and engineering approach over exposing raw source, raw prompts, private data, or operational details.
+
+If code is copied, copy only reviewed, sanitized code. Do not mirror the private repository history.
+
+## Public narrative guidance
+
+Keep public claims grounded. It is acceptable to describe the visible architecture at a high level: Python RAG pipeline, Gemini integration, Chroma retrieval, Dockerized execution, and embedding training workflow. Do not imply deployment status, customer usage, competition results, or data provenance unless supported by sanitized public materials.

--- a/docs/claude/project-overview.md
+++ b/docs/claude/project-overview.md
@@ -1,0 +1,34 @@
+# Project Overview
+
+## When to use this
+
+Use this when you need a quick, file-grounded understanding of what this repository appears to contain before planning or editing.
+
+## What the repository appears to be
+
+This is a Python project for a franchise-related RAG workflow. The tracked files show a pipeline that:
+
+- Builds a Chroma vector store from JSON input with `create_collection.py`.
+- Runs Gemini-backed retrieval and answer generation through `franchise_service.py` and `run_inference.py`.
+- Uses a Gemini-based reranker in `reranker.py`.
+- Includes an embedding-model training script in `emb_dpr.py`, launched by `run_train.sh`.
+- Provides Docker build files for GPU, CPU, and training-oriented images.
+
+The README is a short Korean execution manual focused on Docker image loading, passing `GEMINI_API_KEY`, running `franchise_RAG.sh`, and launching training through `run_train.sh`.
+
+## Stack inferred from files
+
+- Language: Python 3.10 is used in the Dockerfiles.
+- LLM provider: Google Gemini through `google-generativeai` and `google-genai`.
+- Retrieval and vector store: LangChain, Hugging Face embeddings, Chroma.
+- Training: PyTorch, Transformers, PEFT/LoRA, W&B, Accelerate.
+- Runtime wrappers: Bash scripts and Docker.
+- Configuration: `pydantic-settings` with `.env` support in `config.py`.
+
+## Privacy posture
+
+Treat this as a private or restricted repository. The file names and code indicate franchise, contract, QA, and dataset-oriented workflows, so any JSON data, vector databases, local datasets, logs, model artifacts, or generated answers may contain sensitive or proprietary material.
+
+Never disclose private customer details, internal credentials, proprietary client information, restricted government-related materials, or non-public public-sector details in prompts, docs, commits, PRs, logs, examples, screenshots, or public summaries.
+
+Future public portfolio or resume work must be extracted into a separate sanitized repository. Do not convert this original repository into the public showcase.

--- a/docs/claude/release-and-git-hygiene.md
+++ b/docs/claude/release-and-git-hygiene.md
@@ -1,0 +1,33 @@
+# Release and Git Hygiene
+
+## When to use this
+
+Use this before staging, committing, pushing, opening a PR, preparing release notes, or doing any public/showcase cleanup.
+
+## Branch and status discipline
+
+Start by checking the current branch, HEAD commit, and `git status`. Preserve user changes and do not revert unrelated work.
+
+Use a focused branch name that matches the task. Keep commits small enough to review.
+
+## Diff review checklist
+
+Before staging or committing, review `git diff` and confirm:
+
+- Only intended files changed.
+- No product source code changed during documentation-only tasks.
+- No lockfiles, dependency files, Dockerfiles, CI, README, LICENSE, SECURITY.md, `pyproject.toml`, Dependabot config, production config, or public-release cleanup files changed unless explicitly required.
+- No `.env`, logs, vector DBs, datasets, model artifacts, archives, keys, local task files, or generated output were added.
+- No private customer details, credentials, proprietary client information, restricted government-related materials, or non-public public-sector details are present in the commit.
+
+## Commit messages
+
+Use clear, conventional messages when the user provides no project-specific format. Example:
+
+```text
+chore: bootstrap Claude harness docs
+```
+
+## Public release caution
+
+Do not use this repository itself as the public artifact. Public portfolio work belongs in a separate sanitized showcase repository after a dedicated extraction and review step.

--- a/docs/claude/repository-map.md
+++ b/docs/claude/repository-map.md
@@ -1,0 +1,41 @@
+# Repository Map
+
+## When to use this
+
+Use this when you need to find the relevant files for a task or verify that a change stays inside the expected area.
+
+## Top-level files
+
+- `README.md`: Korean Docker execution manual.
+- `requirements.txt`: Python dependencies for RAG, Gemini, Chroma, PyTorch GPU packages, and training.
+- `config.py`: Pydantic settings for `GEMINI_API_KEY`, vector DB path, Gemini model name, embedding model path, and device.
+- `franchise_service.py`: Main Gemini and Chroma RAG service, including few-shot retrieval and answer generation.
+- `reranker.py`: Gemini-based document reranker.
+- `create_collection.py`: Converts input JSON files into Chroma documents and QA pairs.
+- `run_inference.py`: Runs the RAG service and writes inference output to `/app/test/test_data.json`.
+- `franchise_RAG.sh`: Bash entrypoint that builds the vector store and runs inference.
+- `emb_dpr.py`: DPR/LoRA embedding training script using Transformers, PEFT, PyTorch, and W&B.
+- `run_train.sh`: Bash entrypoint that exports `WANDB_API_KEY` and launches training through Accelerate.
+- `check_google_model.py`: Lists Gemini models available for content generation.
+- `sbert-wrapping.py`: Wraps a local transformer model into a SentenceTransformer format.
+- `Dockerfile`: GPU runtime image for RAG inference.
+- `Dockerfile.cpu`: CPU-oriented runtime image.
+- `Dockerfile.train`: GPU training image.
+
+## Data and test fixtures
+
+- `test_data.json`, `test_data_flash1.5.json`, and `test_data_flash2.0.json` are tracked JSON files.
+- `test/` contains tracked JSON files.
+- Ignored local paths include vector databases, datasets, local model directories, logs, archives, and environment files.
+
+Before using any JSON, dataset, vector DB, log, or generated output in a public context, review and sanitize it.
+
+## Ignored local artifacts
+
+The `.gitignore` excludes `.env`, logs, virtual environments, vector database paths, `/data`, local model directories such as `squad-v1/`, `dataset/`, archives, key/certificate files, and common generated artifacts.
+
+Do not assume ignored files are safe to share. Ignored often means local, heavy, secret, or sensitive.
+
+## Current documentation scope
+
+The Claude instruction files live under `docs/claude/`. The root `CLAUDE.md` should remain a short index/router and should not become a large single-file manual.

--- a/docs/claude/security-and-secrets.md
+++ b/docs/claude/security-and-secrets.md
@@ -1,0 +1,32 @@
+# Security and Secrets
+
+## When to use this
+
+Use this for any task touching configuration, environment variables, API calls, logs, JSON fixtures, vector databases, datasets, model artifacts, generated answers, Docker images, or portfolio/public-share work.
+
+## Hard rules
+
+Never expose, commit, paste, summarize publicly, screenshot, or send to external tools:
+
+- Private customer details.
+- Internal credentials or API keys.
+- Proprietary client information.
+- Restricted government-related materials.
+- Non-public public-sector details.
+- Raw contract, franchise, QA, dataset, vector DB, log, or generated-output content that has not been explicitly reviewed and sanitized.
+
+## Secrets visible from code structure
+
+`config.py` requires `GEMINI_API_KEY` and loads `.env`. `run_train.sh` exports `WANDB_API_KEY` from its first argument. `.gitignore` excludes `.env`, keys, certificates, logs, archives, local data, vector DBs, datasets, and model directories.
+
+Keep these values and artifacts out of commits and public examples.
+
+## Handling data safely
+
+Assume JSON files, vector DBs, generated answers, logs, and training datasets may contain sensitive or proprietary information. Use synthetic or explicitly sanitized examples in public-facing docs.
+
+If a task requires inspecting sensitive data, quote the smallest possible amount internally and avoid copying it into commits or final public summaries.
+
+## External services
+
+Gemini and W&B calls can send prompts, examples, metadata, or training information to external services. Do not run external-service workflows with real or sensitive data unless the task explicitly requires it and the user has provided the necessary authorization and credentials.

--- a/docs/claude/testing-and-validation.md
+++ b/docs/claude/testing-and-validation.md
@@ -1,0 +1,36 @@
+# Testing and Validation
+
+## When to use this
+
+Use this when deciding how to verify a change before reporting it as complete.
+
+## What is visible in the repository
+
+The repository does not currently show a pytest suite, CI workflow, `pyproject.toml`, `package.json`, or other formal test runner configuration in the tracked files.
+
+Validation should therefore be proportional to the change and grounded in available files.
+
+## Documentation-only validation
+
+For documentation changes:
+
+- Confirm expected files exist.
+- Check relative Markdown links between `CLAUDE.md` and `docs/claude/`.
+- Review Markdown headings for consistent structure.
+- Run `git diff` and verify that only intended docs changed.
+- Confirm `.codex_task.md` or other local-only files were not staged.
+
+## Code validation
+
+For Python or script changes, choose the lightest useful checks that do not require unavailable secrets or large ignored artifacts:
+
+- Import or syntax checks for changed Python files when feasible.
+- Script help or dry-run behavior when available.
+- Docker build checks only when the task concerns Docker and the local environment supports it.
+- Avoid running Gemini, W&B, model download, CUDA, or vector DB workflows unless the task explicitly requires those external or heavy operations.
+
+## Runtime prerequisites
+
+The code expects `GEMINI_API_KEY` through settings. Training expects `WANDB_API_KEY` through `run_train.sh`. Local model directories, datasets, and vector stores are ignored and may not exist in a fresh checkout.
+
+Do not treat missing local secrets, model artifacts, datasets, or vector DB directories as ordinary code failures unless the task is specifically about setup.

--- a/docs/solutions/documentation-gaps/bootstrap-claude-harness-docs-2026-05-28.md
+++ b/docs/solutions/documentation-gaps/bootstrap-claude-harness-docs-2026-05-28.md
@@ -1,0 +1,79 @@
+---
+title: Bootstrap Claude Harness Docs Without Touching Product Code
+date: 2026-05-28
+category: documentation-gaps
+module: agent-instructions
+problem_type: documentation_gap
+component: documentation
+severity: low
+applies_when:
+  - "Bootstrapping agent instruction files in a private or restricted repository"
+  - "Creating portfolio-readiness guidance without public-release cleanup"
+  - "Validating documentation-only changes before commit"
+tags: [claude-docs, documentation-only, privacy, git-hygiene, codex]
+---
+
+# Bootstrap Claude Harness Docs Without Touching Product Code
+
+## Context
+
+This repository needed Claude/Codex harness instructions, but the task explicitly limited edits to documentation structure and required privacy-first portfolio rules. The repo also had no prior `CLAUDE.md`, no formal Markdown tooling, and a small Python/Docker RAG layout inferred only from tracked files.
+
+Two workflow issues surfaced during execution: some direct PowerShell commands hit a Windows sandbox runner error, and `git diff` did not show new files until they were added with intent-to-add.
+
+## Guidance
+
+For harness-documentation bootstraps, first map the repo from tracked files, then create a short root router plus topic-specific docs. Keep claims file-grounded and avoid adding unsupported product facts.
+
+Use `git add -N` before reviewing a diff for brand-new files. Without intent-to-add, `git diff` can appear empty even though `git status --short` shows untracked documentation.
+
+When a task requires compound learning, treat a `docs/solutions/` entry as a necessary documentation exception to a narrower docs-only boundary, and explain that exception before creating it.
+
+If direct PowerShell filesystem helpers fail under the sandbox, prefer `rg`, targeted `Get-Content`, and git commands that already work in the environment. Escalate only when the required command is blocked and the workflow depends on it.
+
+## Execution Review Notes
+
+- Mistakes: Initial `git diff` review was too weak for brand-new files until intent-to-add made the new Markdown visible in the diff.
+- Wrong assumptions: Assuming an empty unstaged diff was meaningful for untracked files would have hidden the actual documentation changes.
+- Failed attempts: Some direct PowerShell status and filesystem commands failed with a Windows sandbox runner error, while `rg` and `git -C` checks remained usable.
+- Review findings: The first compound note captured the lesson but did not explicitly label every requested category, so the doc was tightened before final completion.
+- Final solutions: Created a concise `CLAUDE.md` router, modular `docs/claude/` topic files, and a categorized `docs/solutions/` learning.
+- Prevention rules: Use `git add -N` for new-file diff review, verify committed filenames with `git show --name-only HEAD`, and keep privacy/showcase guidance explicit in agent docs.
+
+## Why This Matters
+
+Agent instruction docs can easily drift into invented architecture notes or accidental public-release work. Keeping the docs modular, grounded, and privacy-centered makes future sessions safer without changing application behavior.
+
+The `git add -N` step is especially important because an empty `git diff` on untracked files can produce false confidence during review.
+
+## When to Apply
+
+- When adding or refreshing `CLAUDE.md`, `AGENTS.md`, or agent-facing docs in a private repo.
+- When the task is documentation-only but still requires a reusable learning artifact.
+- When validating new Markdown files before staging and committing.
+- When sandbox behavior differs across direct PowerShell, `rg`, and git commands.
+
+## Examples
+
+Documentation-only validation sequence:
+
+```powershell
+git status
+rg --files
+git add -N CLAUDE.md docs/claude docs/solutions
+git diff --name-only
+git diff --stat
+git diff
+```
+
+Privacy rule to preserve in future instruction docs:
+
+```text
+Future public portfolio work must happen in a separate sanitized showcase repository, not by making the private repository public.
+```
+
+## Related
+
+- [../../claude/README.md](../../claude/README.md)
+- [../../claude/security-and-secrets.md](../../claude/security-and-secrets.md)
+- [../../claude/portfolio-showcase-rules.md](../../claude/portfolio-showcase-rules.md)


### PR DESCRIPTION
## Summary
- Add Claude Code harness docs through CLAUDE.md and docs/claude/.
- Add AGENTS.md as a Codex/general-agent router.
- Keep private-repo privacy, secret-handling, and portfolio-showcase boundaries explicit.
- No product code changes.

## Validation
- Documentation-only scope.
- Product code not changed.
- .codex_task.md not committed.
- Harness branch previously pushed and reviewed locally.